### PR TITLE
Add support for https enabled Gitbooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,6 @@ module.exports = {
         }
     },
     book:{
-        js: ["http://www.websequencediagrams.com/service.js"]
+        js: ["https://www.websequencediagrams.com/service.js"]
     }
 };


### PR DESCRIPTION
When running your Gitbook from an HTTPS enabled website the Websequencediagrams plugin currently does not work because of mixed content (the `service.js` file is loaded through http). Modern browsers block this:

```
Blocked loading mixed active content "http://www.websequencediagrams.com/service.js"`
```
